### PR TITLE
visibility of the screen rotation and screen flip icons

### DIFF
--- a/library/src/main/java/info/hannes/cvscanner/CVScanner.kt
+++ b/library/src/main/java/info/hannes/cvscanner/CVScanner.kt
@@ -84,6 +84,13 @@ object CVScanner {
         activity.startActivityForResult(intent, reqCode)
     }
 
+    fun startManualCropper(activity: Activity, inputImageUri: Uri, reqCode: Int, isVisibleRotateIcons:Boolean, orientationPortrait:Boolean) {
+        val intent = Intent(activity, CropImageActivity::class.java)
+        intent.putExtra(CropImageActivity.EXTRA_IMAGE_URI, inputImageUri.toString())
+        intent.putExtra(CropImageActivity.EXTRA_ROTATE_ICONS_VISIBILITY, isVisibleRotateIcons)
+        intent.putExtra(CropImageActivity.EXTRA_ORIENTATION_PORTRAIT, orientationPortrait)
+        activity.startActivityForResult(intent, reqCode)
+    }
     interface ImageProcessorCallback {
         fun onImageProcessingFailed(reason: String?, error: Exception?)
         fun onImageProcessed(imagePath: String?)

--- a/library/src/main/java/info/hannes/cvscanner/crop/CropImageActivity.kt
+++ b/library/src/main/java/info/hannes/cvscanner/crop/CropImageActivity.kt
@@ -16,6 +16,7 @@
 package info.hannes.cvscanner.crop
 
 import android.app.Activity
+import android.content.pm.ActivityInfo
 import android.net.Uri
 import android.os.Bundle
 import android.view.View
@@ -65,7 +66,13 @@ class CropImageActivity : AppCompatActivity(), ImageProcessorCallback {
             val saveImageResId = extras.getInt(EXTRA_SAVE_IMAGE_RES, R.drawable.ic_check_circle)
             val rtColorResId = extras.getInt(EXTRA_ROTATE_BTN_COLOR_RES, R.color.colorPrimary)
             val saveColorResId = extras.getInt(EXTRA_SAVE_BTN_COLOR_RES, R.color.colorAccent)
-            val fragment = ImageCropperFragment.instantiate(imageUri, saveColorResId, rtColorResId, rtlImageResId, rtrImageResId, saveImageResId)
+            val rtIconsVisibility = extras.getBoolean(EXTRA_ROTATE_ICONS_VISIBILITY)
+            val orientationPortrait = extras.getBoolean(EXTRA_ORIENTATION_PORTRAIT)
+
+            if(orientationPortrait){
+                requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_SENSOR_PORTRAIT
+            }
+            val fragment = ImageCropperFragment.instantiate(imageUri, saveColorResId, rtColorResId, rtlImageResId, rtrImageResId, saveImageResId, rtIconsVisibility)
             supportFragmentManager.beginTransaction()
                 .add(R.id.container, fragment)
                 .commitAllowingStateLoss()
@@ -90,6 +97,8 @@ class CropImageActivity : AppCompatActivity(), ImageProcessorCallback {
         const val EXTRA_ROTATE_RIGHT_IMAGE_RES = "rotateRight_imageRes"
         const val EXTRA_SAVE_BTN_COLOR_RES = "save_imageColorRes"
         const val EXTRA_ROTATE_BTN_COLOR_RES = "rotate_imageColorRes"
+        const val EXTRA_ROTATE_ICONS_VISIBILITY= "rotate_icons_visibility"
+        const val EXTRA_ORIENTATION_PORTRAIT = "orientation_portrait"
         private fun setResultAndExit(cropImageActivity: CropImageActivity, imagePath: String?) {
             val data = cropImageActivity.intent
             data.putExtra(CVScanner.RESULT_IMAGE_PATH, imagePath)

--- a/library/src/main/java/info/hannes/cvscanner/crop/ImageCropperFragment.java
+++ b/library/src/main/java/info/hannes/cvscanner/crop/ImageCropperFragment.java
@@ -16,6 +16,7 @@ import android.widget.Toast;
 
 import androidx.annotation.ColorRes;
 import androidx.annotation.DrawableRes;
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.core.graphics.drawable.DrawableCompat;
 
@@ -37,6 +38,7 @@ public class ImageCropperFragment extends BaseCVFragment implements CropImageVie
     final static String ARG_RT_RIGHT_IMAGE_RES = "rotateRight_imageRes";
     final static String ARG_SAVE_IMAGE_COLOR_RES = "save_imageColorRes";
     final static String ARG_RT_IMAGE_COLOR_RES = "rotate_imageColorRes";
+    final static String ARG_RT_ICONS_VISIBILITY = "rotate_icons_visibility";
     protected CropImageView mImageView;
     protected ImageButton mRotateLeft;
     protected ImageButton mRotateRight;
@@ -46,6 +48,7 @@ public class ImageCropperFragment extends BaseCVFragment implements CropImageVie
     protected Bitmap mBitmap;
     protected Uri imageUri = null;
     protected ImageLoadingCallback mImageLoadingCallback = null;
+    protected Boolean rtIconsVisibility;
 
     public static ImageCropperFragment instantiate(Uri imageUri) {
         ImageCropperFragment fragment = new ImageCropperFragment();
@@ -58,7 +61,7 @@ public class ImageCropperFragment extends BaseCVFragment implements CropImageVie
 
     public static ImageCropperFragment instantiate(Uri imageUri, @ColorRes int buttonTint,
                                                    @ColorRes int buttonTintSecondary, @DrawableRes int rotateLeftRes,
-                                                   @DrawableRes int rotateRightRes, @DrawableRes int saveButtonRes) {
+                                                   @DrawableRes int rotateRightRes, @DrawableRes int saveButtonRes,Boolean rtIconsVisibility) {
         ImageCropperFragment fragment = new ImageCropperFragment();
         Bundle args = new Bundle();
         args.putString(ARG_SRC_IMAGE_URI, imageUri.toString());
@@ -67,6 +70,7 @@ public class ImageCropperFragment extends BaseCVFragment implements CropImageVie
         args.putInt(ARG_RT_LEFT_IMAGE_RES, rotateLeftRes);
         args.putInt(ARG_RT_RIGHT_IMAGE_RES, rotateRightRes);
         args.putInt(ARG_SAVE_IMAGE_RES, saveButtonRes);
+        args.putBoolean(ARG_RT_ICONS_VISIBILITY, rtIconsVisibility);
         fragment.setArguments(args);
 
         return fragment;
@@ -85,7 +89,7 @@ public class ImageCropperFragment extends BaseCVFragment implements CropImageVie
     @Override
     public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.imagecropper_content, container, false);
-
+        
         initializeViews(view);
 
         return view;
@@ -110,6 +114,7 @@ public class ImageCropperFragment extends BaseCVFragment implements CropImageVie
         Drawable saveBtnDrawable = getResources().getDrawable(extras.getInt(ARG_SAVE_IMAGE_RES, R.drawable.ic_check_circle));
         Drawable rotateLeftDrawable = getResources().getDrawable(extras.getInt(ARG_RT_LEFT_IMAGE_RES, R.drawable.ic_rotate_left));
         Drawable rotateRightDrawable = getResources().getDrawable(extras.getInt(ARG_RT_RIGHT_IMAGE_RES, R.drawable.ic_rotate_right));
+        rtIconsVisibility = extras.getBoolean(ARG_RT_ICONS_VISIBILITY);
 
         DrawableCompat.setTint(rotateLeftDrawable, secondaryBtnTintColor);
         mRotateLeft.setImageDrawable(rotateLeftDrawable);
@@ -218,8 +223,10 @@ public class ImageCropperFragment extends BaseCVFragment implements CropImageVie
 
     private void adjustButtons() {
         if (mBitmap != null) {
-            mRotateLeft.setVisibility(View.VISIBLE);
-            mRotateRight.setVisibility(View.VISIBLE);
+            if(!rtIconsVisibility){
+                mRotateLeft.setVisibility(View.VISIBLE);
+                mRotateRight.setVisibility(View.VISIBLE);
+            }
             mSave.setVisibility(View.VISIBLE);
         } else {
             mRotateLeft.setVisibility(View.GONE);


### PR DESCRIPTION
Hello,

I had a problem with the image rotate icons not working properly and I have added that you can modify their visibility to not show them. Also if the screen rotation is enabled (landscape) the image is positioned wrong when rotated, I have also added the possibility to always stay in portrait.

Both ways I have added them of optional form, calling it of the following way

startManualCropper(activity: Activity, inputImageUri: Uri, reqCode: Int, isVisibleRotateIcons:Boolean, orientationPortrait:Boolean)

You would be kind enough to accept the change,

thank you very much,
best regards
