### PR TITLE
Bump com.github.hannesa2:AndroidVisionPipeline from 1.1 to 1.2.1

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -47,7 +47,7 @@ dependencies {
     implementation 'androidx.exifinterface:exifinterface:1.3.6'
     implementation 'com.google.android.gms:play-services-basement:18.2.0'
     implementation 'com.google.android.gms:play-services-vision:20.1.3'
-    api 'com.github.hannesa2:AndroidVisionPipeline:1.1'
+    api 'com.github.hannesa2:AndroidVisionPipeline:1.2.1'
 
     implementation "androidx.core:core-ktx:1.10.1"
     implementation "androidx.collection:collection-ktx:1.2.0"


### PR DESCRIPTION
Bumps com.github.hannesa2:AndroidVisionPipeline from 1.1 to 1.2.1.

---
updated-dependencies:
- dependency-name: com.github.hannesa2:AndroidVisionPipeline dependency-type: direct:production update-type: version-update:semver-minor ...